### PR TITLE
Remove unneeded null handling in test for word ladder

### DIFF
--- a/kotlin/problems/src/test/kotlin/com/alicia/problems/graph/WordLadderTest.kt
+++ b/kotlin/problems/src/test/kotlin/com/alicia/problems/graph/WordLadderTest.kt
@@ -12,9 +12,9 @@ class WordLadderTest {
         val expected = listOf("HEAD", "HEAL", "TEAL", "TELL", "TALL", "TAIL")
         val result = WordLadder.findWordLadder("HEAD", "TAIL")
 
-        assertEquals(expected.size, result?.size)
+        assertEquals(expected.size, result.size)
         for(i in expected.indices) {
-            assertEquals(expected[i], result!![i], "Expected ${expected[i]} but was ${result[i]}")
+            assertEquals(expected[i], result[i], "Expected ${expected[i]} but was ${result[i]}")
         }
     }
 


### PR DESCRIPTION
Pull request #5 made return type of word ladder problem non-nullable. Remove null handling in unit tests since it is unneeded.